### PR TITLE
Test that MX::ABC will not cause new to die if loaded before MX::StrictConstructor 

### DIFF
--- a/t/05-mx-strict-constructor.t
+++ b/t/05-mx-strict-constructor.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Requires;
+
+test_requires 'MooseX::StrictConstructor';
+
+{
+    package Before;
+    use Moose;
+    use MooseX::ABC;
+    use MooseX::StrictConstructor;
+
+    __PACKAGE__->meta->make_immutable;
+}
+
+dies_ok {
+    Before->new;
+} 'Before->new() dies';
+
+{
+    package Foo;
+    use Moose;
+    extends 'Before';
+
+    __PACKAGE__->meta->make_immutable;
+}
+
+dies_ok {
+    Foo->new( attr => 'bar' );
+} 'Foo->new() dies';
+
+{
+    package After;
+    use Moose;
+    use MooseX::StrictConstructor;
+    use MooseX::ABC;
+
+    __PACKAGE__->meta->make_immutable;
+}
+
+dies_ok {
+    After->new;
+} 'After->new() dies';
+
+{
+    package Bar;
+    use Moose;
+    extends 'After';
+
+    __PACKAGE__->meta->make_immutable;
+}
+
+dies_ok {
+    Bar->new( attr => 'bar' );
+} 'Bar->new() dies';
+
+done_testing;


### PR DESCRIPTION
MX::ABC will not cause new to die if loaded before MX::StrictConstructor

Signed-off-by: Caleb Cushing xenoterracide@gmail.com
